### PR TITLE
Fix aws testing race

### DIFF
--- a/.ci-integration-tests.yml
+++ b/.ci-integration-tests.yml
@@ -1,1 +1,2 @@
 pipeline_template: ci/modules/Jenkinsfile-integration-tests
+lock: aws

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -77,7 +77,7 @@ def vpc(ec2, resource_name_prefix, cleanup):
             )
             tag_creation_succeeded = True
         except botocore.exceptions.ClientError:
-            time.sleep(1)
+            time.sleep(5)
         tries -= 1
 
     if not tag_creation_succeeded:


### PR DESCRIPTION
# Description

An attempt to make the aws tests more stable.
The tests seemed to break when being ran in rapid succession or simultaniously. (eg the modulesets would test at the same time)
Adding a lock and slowing down the the retries of the creation of tags seems to have made them more stable.
Tested by queuing up multiple builds of this branch.

# Merge procedure

Don't use the github built-in merge, but the process described [here](https://docs.internal.inmanta.com/topics/tasks/commiting_changes_modules.html)

```sh
git pull
git checkout master
git pull
git merge --squash issue/{issue-number}-{short description}
inmanta module commit -m "{Commit Message Here}" -r
git push
git push {tag} # push the tag as well
```

Then close the PR with a reference to the commit

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] ~~Attached issue to pull request~~
- [ ] ~~Changelog entry~~
- [ ] ~~Version number is bumped to dev version~~
- [x] Code is clear and sufficiently documented
- [ ] ~~Sufficient test cases (reproduces the bug/tests the requested feature)~~
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
