### PR TITLE
[FIX] change exception type to ExternalException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+v3.1.5
+- Fix exception type in test_vm_subnets
+
 V3.1.4
 - Fix for incorrect retry in subnet creation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-v3.1.5
+v3.1.6
 - Fix exception type in test_vm_subnets
 
 V3.1.4

--- a/module.yml
+++ b/module.yml
@@ -1,5 +1,5 @@
 author: Inmanta <code@inmanta.com>
 license: Apache 2.0
 name: aws
-version: 3.1.6.dev1646404630
+version: 3.1.6.dev1646406985
 compiler_version: 2017.2

--- a/module.yml
+++ b/module.yml
@@ -1,5 +1,5 @@
 author: Inmanta <code@inmanta.com>
 license: Apache 2.0
 name: aws
-version: 3.1.5
+version: 3.1.6.dev1646404630
 compiler_version: 2017.2

--- a/module.yml
+++ b/module.yml
@@ -1,5 +1,5 @@
 author: Inmanta <code@inmanta.com>
 license: Apache 2.0
 name: aws
-version: 3.1.6.dev1646406985
+version: 3.1.6.dev1646407799
 compiler_version: 2017.2

--- a/tests/test_aws.py
+++ b/tests/test_aws.py
@@ -19,6 +19,7 @@ import logging
 
 import pytest
 from conftest import retry_limited
+from inmanta.ast import ExternalException
 
 # States that indicate that an instance is terminated or is getting terminated
 INSTANCE_TERMINATING_STATES = ["terminated", "shutting-down"]
@@ -138,7 +139,7 @@ subnet = aws::Subnet(name="test", provider=provider, cidr_block="10.0.0.0/24", v
     )
 
     # set none
-    with pytest.raises(ValueError):
+    with pytest.raises((ExternalException, ValueError)):  # need ValueError here so that the test doesn't fail for stable products
         project.compile(
             f"""
 import unittest
@@ -154,7 +155,7 @@ aws::VirtualMachine(provider=provider, flavor="t2.small", image="{latest_amzn_im
         )
 
     # set both
-    with pytest.raises(ExternalException):  # NOQA F821
+    with pytest.raises((ExternalException, ValueError)):  # need ValueError here so that the test doesn't fail for stable products
         project.compile(
             f"""
 import unittest

--- a/tests/test_aws.py
+++ b/tests/test_aws.py
@@ -154,7 +154,7 @@ aws::VirtualMachine(provider=provider, flavor="t2.small", image="{latest_amzn_im
         )
 
     # set both
-    with pytest.raises(ValueError):
+    with pytest.raises(ExternalException):  # NOQA F821
         project.compile(
             f"""
 import unittest

--- a/tests/test_aws.py
+++ b/tests/test_aws.py
@@ -139,7 +139,9 @@ subnet = aws::Subnet(name="test", provider=provider, cidr_block="10.0.0.0/24", v
     )
 
     # set none
-    with pytest.raises((ExternalException, ValueError)):  # need ValueError here so that the test doesn't fail for stable products
+    with pytest.raises(
+        (ExternalException, ValueError)
+    ):  # need ValueError here so that the test doesn't fail for stable products
         project.compile(
             f"""
 import unittest
@@ -155,7 +157,9 @@ aws::VirtualMachine(provider=provider, flavor="t2.small", image="{latest_amzn_im
         )
 
     # set both
-    with pytest.raises((ExternalException, ValueError)):  # need ValueError here so that the test doesn't fail for stable products
+    with pytest.raises(
+        (ExternalException, ValueError)
+    ):  # need ValueError here so that the test doesn't fail for stable products
         project.compile(
             f"""
 import unittest


### PR DESCRIPTION
# Description
Test was failing because it was waiting for an exception that is no longer raised with the same type


# Merge procedure

Don't use the github built-in merge, but the process described [here](https://docs.internal.inmanta.com/topics/tasks/commiting_changes_modules.html)

```sh
git pull
git checkout master
git pull
git merge --squash issue/{issue-number}-{short description}
inmanta module commit -m "{Commit Message Here}" -r
git push
git push {tag} # push the tag as well
```

Then close the PR with a reference to the commit

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Version number is bumped to dev version
- [ ] Code is clear and sufficiently documented
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
