### PR TITLE
Migrate test suite to Amazon Linux 2 AMI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v4.0.2 - ?
 
-- Migrate test suite from Amazon Linux 1 to Amazon Linux2 AMI
+- Migrate test suite from Amazon Linux 1 to Amazon Linux 2 AMI
 
 ## v4.0.1 - 2024-03-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v4.0.2 - ?
 
+- Migrate test suite from Amazon Linux 1 to Amazon Linux2 AMI
 
 ## v4.0.1 - 2024-03-29
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,7 +60,7 @@ def elb(session):
 def latest_amzn_image(ec2):
     result = ec2.images.filter(
         Owners=["amazon"],
-        Filters=[{"Name": "name", "Values": ["amzn-ami-hvm-*-x86_64-gp2"]}],
+        Filters=[{"Name": "name", "Values": ["amzn2-ami-kernel-*-hvm-*-x86_64-gp2"]}]
     )
     name_to_image_dct = {r.meta.data["Name"]: r for r in result}
     name_latest_image = sorted(name_to_image_dct.keys())[-1]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,7 +60,7 @@ def elb(session):
 def latest_amzn_image(ec2):
     result = ec2.images.filter(
         Owners=["amazon"],
-        Filters=[{"Name": "name", "Values": ["amzn2-ami-kernel-*-hvm-*-x86_64-gp2"]}]
+        Filters=[{"Name": "name", "Values": ["amzn2-ami-kernel-*-hvm-*-x86_64-gp2"]}],
     )
     name_to_image_dct = {r.meta.data["Name"]: r for r in result}
     name_latest_image = sorted(name_to_image_dct.keys())[-1]


### PR DESCRIPTION
# Description

Migrate test suite from Amazon Linux 1 to Amazon Linux 2 AMI.

The existing filter didn't return any images anymore, because the naming schema of the image changed. Since the Amazon Linux 1 AMI is deprecated, I moved it to the Amazon Linux 2 AMI.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Version number is bumped to dev version
- [x] Code is clear and sufficiently documented
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
